### PR TITLE
taskモーダル追加

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,5 @@
 class Task < ApplicationRecord
   belongs_to :weekly_goal
+  validates :start_time   , presence: true
+  validates :end_time     , presence: true
 end

--- a/app/models/weekly_goal.rb
+++ b/app/models/weekly_goal.rb
@@ -1,6 +1,7 @@
 class WeeklyGoal < ApplicationRecord
   belongs_to :user
   belongs_to :monthly_goal
+  has_many :task, dependent: :destroy
 
   validates :weekly_goal , presence:true, length: { maximum: 100 }
 end

--- a/app/views/monthly_goals/my_goal.html.slim
+++ b/app/views/monthly_goals/my_goal.html.slim
@@ -25,7 +25,7 @@ section
            a.weekly_goal[href="#" data-toggle="modal" data-target="#myModal" data-day=date] 週間目標
            
          li
-           a[href="#" data-toggle="modal" data-target="#add_task"] タスク
+           a[href="#" data-toggle="modal" data-target="#add_task" data-day=date] タスク
          
          
          
@@ -49,6 +49,7 @@ section.penalty
     = f.file_field :image
     = f.submit '更新'
 = render partial: 'weekly_goals/add_weekly_goal'
+= render partial: 'tasks/task_modal'
 
   
 

--- a/app/views/tasks/_task_modal.html.slim
+++ b/app/views/tasks/_task_modal.html.slim
@@ -1,0 +1,17 @@
+.modal.fade role="dialog" id="add_task" aria-labelledby="exampleModalLabel"
+  .modal-dialog role="document"
+    .modal-content
+      .modal-header
+        button.close type="button" data-dismiss="modal" aria-label="Close"
+          span aria-hidden="true" &times;
+        h4.modal-title 週間目標
+      .modal-body
+        .js-task-errors
+        = form_with model: @task, scope: :task,local: false do |f|
+          = f.label       :task, "タスク",          class: "control-label"
+          = f.text_field  :task,                    class: "form-control"
+          = f.label       :start_time, "開始日時",  class: "control-label"
+          = f.date_field  :start_time,              class: "form-control"
+          .modal-footer
+            = button_to "閉じる", "#", type: "button", class: "btn btn-default", data: { toggle: "modal", target: "#add_task" }
+            = f.submit "登録", class: "btn btn-primary"

--- a/app/views/weekly_goals/_add_weekly_goal.html.slim
+++ b/app/views/weekly_goals/_add_weekly_goal.html.slim
@@ -17,15 +17,4 @@
             = button_to "閉じる", "#", type: "button", class: "btn btn-default", data: { toggle: "modal", target: "#myModal" }
             = f.submit "登録", class: "btn btn-primary"
 
-.modal.fade tabindex="-1" role="dialog" id="add_task"
-  .modal-dialog role="document"
-    .modal-content
-      .modal-header
-        button.close type="button" data-dismiss="modal" aria-label="Close"
-          span aria-hidden="true" &times;
-        h4.modal-title 今日のタスク
-      .modal-body
-        input.form-control
-      .modal-footer
-        = button_to "閉じる", "#", type: "button", class: "btn btn-default", data: { dismiss: "modal" }
-        = button_to "登録する", { controller: 'tasks', action: 'create' }, type: "button", class: "btn btn-primary"
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_11_085648) do
+ActiveRecord::Schema.define(version: 2023_09_28_145303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,16 @@ ActiveRecord::Schema.define(version: 2023_09_11_085648) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_monthly_goals_on_user_id"
+  end
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "task"
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.bigint "weekly_goal_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["weekly_goal_id"], name: "index_tasks_on_weekly_goal_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -57,6 +67,7 @@ ActiveRecord::Schema.define(version: 2023_09_11_085648) do
   end
 
   add_foreign_key "monthly_goals", "users"
+  add_foreign_key "tasks", "weekly_goals"
   add_foreign_key "weekly_goals", "monthly_goals"
   add_foreign_key "weekly_goals", "users"
 end


### PR DESCRIPTION

変更内容
①models/task.rbにバリデーションの追加

②models/weekly_goal.rbに関連付け追加

変更理由
①に関してデータベースのデータの整合性を保つため

②に関してweekly_goalを削除したらtaskも同様削除されるようにしてユーザーの使いやすさ向上

