### PR TITLE
カレンダーにタスクを表示

### DIFF
--- a/app/controllers/monthly_goals_controller.rb
+++ b/app/controllers/monthly_goals_controller.rb
@@ -9,10 +9,9 @@ class MonthlyGoalsController < ApplicationController
     @user = User.find(params[:id])
     @monthly_goal = @user.monthly_goal
     @days_until_achievement = @monthly_goal.calc_days(@monthly_goal.goal_achieved_at)
-    @events = @user.weekly_goals
+    @events = @user.weekly_goals.includes(:tasks)
     @task = Task.new
-
-
+  
   end
 
   # GET /monthly_goals/1 or /monthly_goals/1.json

--- a/app/models/weekly_goal.rb
+++ b/app/models/weekly_goal.rb
@@ -1,7 +1,7 @@
 class WeeklyGoal < ApplicationRecord
   belongs_to :user
   belongs_to :monthly_goal
-  has_many :task, dependent: :destroy
+  has_many :tasks, dependent: :destroy
 
   validates :weekly_goal , presence:true, length: { maximum: 100 }
 end

--- a/app/views/monthly_goals/my_goal.html.slim
+++ b/app/views/monthly_goals/my_goal.html.slim
@@ -14,8 +14,8 @@ section
 
 section 
   h4 やることカレンダー
-  = month_calendar events: @events do |date, events|
-    = date
+  = month_calendar attribute: :start_time, end_attribute: :end_time, events: @events do |date, events|
+    = date.day
     .dropdown
        button.btn.btn-default.dropdown-toggle(type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" )
         | +
@@ -26,12 +26,20 @@ section
            
          li
            a.task[href="#" data-toggle="modal" data-target="#add_task" data-day=date] タスク
-         
-         
-         
+ 
     - events.each do |event|
       div
         = event.weekly_goal
+        - event.tasks.each do |task|
+          div
+            = task.task
+        
+        
+    
+        
+
+     
+      
    
               
 section.penalty

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module SharedGoalApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
     config.i18n.default_locale = :ja
+    
 
     config.generators do |g| 
       g.test_framework :rspec,


### PR DESCRIPTION

変更内容
①monthly_goals_controller.rbでユーザーの週間目標だけでなく、タスクも同時に取得しました。

②my_goal.html.slimの画面編集

変更目的
①1つのカレンダーに週間目標とタスク両方を表示させるため
②タスクを表示できるようにしました