### PR TITLE
カレンダー週間目標削除機能追加

### DIFF
--- a/app/controllers/weekly_goals_controller.rb
+++ b/app/controllers/weekly_goals_controller.rb
@@ -1,5 +1,6 @@
 class WeeklyGoalsController < ApplicationController
-  before_action :set_weekly_goal, only: %i[ show edit update destroy ]
+  before_action :set_weekly_goal,   only: %i[ show edit update  ]
+  before_action :find_current_user, only: %i[ create destroy  ]
 
   # GET /weekly_goals or /weekly_goals.json
   def index
@@ -24,7 +25,6 @@ class WeeklyGoalsController < ApplicationController
   def create
     
     @weekly_goal = WeeklyGoal.new(weekly_goal_params)
-    @user = User.find(params[:id])
     respond_to do |format|
       if @weekly_goal.save
         format.html { redirect_to my_goal_monthly_goal_path(@user) , notice: "Weekly goal was successfully created." }
@@ -54,10 +54,9 @@ class WeeklyGoalsController < ApplicationController
 
   # DELETE /weekly_goals/1 or /weekly_goals/1.json
   def destroy
-    @weekly_goal.destroy
-
+    @user.weekly_goals
     respond_to do |format|
-      format.html { redirect_to weekly_goals_url, notice: "Weekly goal was successfully destroyed." }
+      format.html { redirect_to my_goal_monthly_goal_path(@user) , notice: "Weekly goal was successfully destroyed." }
       format.json { head :no_content }
     end
   end
@@ -68,9 +67,12 @@ class WeeklyGoalsController < ApplicationController
       @weekly_goal = WeeklyGoal.find(params[:id])
     end
 
+    def find_current_user
+      @user = User.find(params[:id])
+    end
+
     # Only allow a list of trusted parameters through.
     def weekly_goal_params
       params.require(:weekly_goal).permit(:weekly_goal, :start_time, :user_id, :monthly_goal_id)
-      
     end
 end

--- a/app/views/monthly_goals/my_goal.html.slim
+++ b/app/views/monthly_goals/my_goal.html.slim
@@ -14,6 +14,9 @@ section
 
 section 
   h4 やることカレンダー
+ 
+  
+  
   = month_calendar attribute: :start_time, end_attribute: :end_time, events: @events do |date, events|
     = date.day
     .dropdown
@@ -58,6 +61,8 @@ section.penalty
     = f.submit '更新'
 = render partial: 'weekly_goals/add_weekly_goal'
 = render partial: 'tasks/task_modal'
+
+
 
   
 

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -2,9 +2,16 @@
   <div class="calendar-heading">
     <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
     <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
-    <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>  
+                <%= button_to "全削除","/weekly_goals/#{@user.id}" , { method: :delete,class: "btn btn-danger" ,data: { confirm: '本当に週間目標とタスクを全て削除しますか？' }} %>
+               
+            </div>
+        </div>
+    </div>
+</div>
+     
   </div>
-  
+
   <table class="table table-striped">
     <thead>
       <tr>
@@ -13,22 +20,23 @@
         <% end %>
       </tr>
     </thead>
+
     <tbody>
       <% date_range.each_slice(7) do |week| %>
         <tr>
           <% week.each do |day| %>
-            <%= content_tag :td, class: calendar.td_classes_for(day)  do %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
               <% if defined?(Haml) && respond_to?(:block_is_haml?) && block_is_haml?(passed_block) %>
                 <% capture_haml(day, sorted_events.fetch(day, []), &passed_block) %>
               <% else %>
                 <% passed_block.call day, sorted_events.fetch(day, []) %>
               <% end %>
-            <% end %>          
+            <% end %>
           <% end %>
         </tr>
       <% end %>
     </tbody>
   </table>
 </div>
-  </div>
-              
+
+


### PR DESCRIPTION

変更内容
①カレンダー上に削除ボタン追加

②週間目標を削除できるようにコントローラーにdestroyアクション内でユーザーの週間目標を取得

目的
①ユーザーが間違って登録したものを削除できるようにするため