### PR TITLE
バグ修正(#111)

### DIFF
--- a/app/controllers/monthly_goals_controller.rb
+++ b/app/controllers/monthly_goals_controller.rb
@@ -9,10 +9,11 @@ class MonthlyGoalsController < ApplicationController
     @user = User.find(params[:id])
     @monthly_goal = @user.monthly_goal
     @days_until_achievement = @monthly_goal.calc_days(@monthly_goal.goal_achieved_at)
-    @events = @user.weekly_goals.includes(:tasks)
-
-    @task = Task.new
     @weekly_goals = @user.weekly_goals
+    @events = @user.collect_user_events(@weekly_goals)
+    @task = Task.new
+    
+    
 
   end
 

--- a/app/controllers/weekly_goals_controller.rb
+++ b/app/controllers/weekly_goals_controller.rb
@@ -105,7 +105,7 @@ end
 
     # Only allow a list of trusted parameters through.
     def weekly_goal_params
-      byebug
+      
       params.require(:weekly_goal).permit(:weekly_goal, :start_time, :user_id, :monthly_goal_id)
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,17 @@ class User < ApplicationRecord
          validates :name , presence:true,  uniqueness: true
          
 
+def collect_user_events(user_weekly_goals)
+  events = []
+  user_weekly_goals.each do |weekly_goal|
+    events.push(weekly_goal)
+  weekly_goal.tasks.each do |task|
+    events.push(task)
+    end
+  end 
+  events
+end 
+
 
 end 
 

--- a/app/views/monthly_goals/my_goal.html.slim
+++ b/app/views/monthly_goals/my_goal.html.slim
@@ -18,7 +18,7 @@ section
  
   
   
-  = month_calendar attribute: :start_time, end_attribute: :end_time, events: @events do |date, events|
+  = month_calendar attribute: :start_time, end_attribute: :end_time,events: @events do |date, events|
     = date.day
     .dropdown
        button.btn.btn-default.dropdown-toggle(type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" )
@@ -34,18 +34,18 @@ section
             a.task[href="#" data-toggle="modal" data-target="#add_task" data-day=date] タスク
          
 
-    - events.each do |weekly_goal|
-      div.container
-        p[class = "weekly_goal_link_#{weekly_goal.id}"]
-          = link_to weekly_goal.weekly_goal ,  '#',class: "weekly_goal_display_#{weekly_goal.id}", data: { date: weekly_goal.start_time.to_s, content: weekly_goal.weekly_goal }
-        p 
-          = link_to "編集",    '#'  ,        class: "weekly_goal_edit_#{weekly_goal.id}",data: { id: weekly_goal.id }
-        p 
-          = link_to "削除",    '#'  ,        class: "weekly_goal_destroy_#{weekly_goal.id}"
-        
-        - weekly_goal.tasks.each do |task|
-          div
-            = task.task
+    - events.each do |event|
+      - if event.is_a?(WeeklyGoal)
+        div.container
+          p[class = "weekly_goal_link_#{event.id}"]
+            = link_to event.weekly_goal ,  '#',class: "weekly_goal_display_#{event.id}", data: { date: event.start_time.to_s, content: event.weekly_goal }
+          p 
+            = link_to "編集",    '#'  ,        class: "weekly_goal_edit_#{event.id}",data: { id: event.id }
+          p 
+            = link_to "削除",    '#'  ,        class: "weekly_goal_destroy_#{event.id}"
+      - else 
+        div
+          = event.task
         
               
 section.penalty


### PR DESCRIPTION

変更内容
①カレンダー内の適切な箇所にタスクを表示できるようにしました。


目的
①ユーザーさんがタスクの登録した日にちを困惑しないようにするため