### PR TITLE
Relationshipテーブルの作成と 関連付けをした

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,6 @@
+class Relationship < ApplicationRecord
+  belongs_to :sender,   class_name: "User"
+  belongs_to :reciever, class_name: "User"
+  validates :follower_id, presence: true
+  validates :followed_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
-  has_one :monthly_goal
+  has_one  :monthly_goal
   has_many :weekly_goals, through: :monthly_goal
+  has_one  :send_relationships,   class_name:  "Relationship",
+                                  foreign_key: "sender_id",
+                                  dependent:   :destroy
 
   
 

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,8 +1,9 @@
 header
   nav
     ul
+      li= link_to 'マイページ'  , '#'
+      li= link_to 'ログアウト  ', '#'
       li= link_to 'マイページ', '#'
-      li= link_to 'ログアウト', '#'
       -if yield :title == "マイゴール"
       = search_form_for @q , url: url_for(controller: 'users', action: 'search') do |f|
         .search

--- a/db/migrate/20231030055843_create_relationships.rb
+++ b/db/migrate/20231030055843_create_relationships.rb
@@ -1,0 +1,11 @@
+class CreateRelationships < ActiveRecord::Migration[6.1]
+  def change
+    create_table :relationships do |t|
+      t.integer :sender_id
+      t.integer :reciever_id
+
+      t.timestamps
+    end
+    add_index :relationships, [:sender_id, :reciever_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_28_145303) do
+ActiveRecord::Schema.define(version: 2023_10_30_055843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,14 @@ ActiveRecord::Schema.define(version: 2023_09_28_145303) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_monthly_goals_on_user_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "sender_id"
+    t.integer "reciever_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["sender_id", "reciever_id"], name: "index_relationships_on_sender_id_and_reciever_id", unique: true
   end
 
   create_table "tasks", force: :cascade do |t|

--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :relationship do
+    sender_id { 1 }
+    reciever_id { 1 }
+  end
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Relationship, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION

変更内容
①Relationshipテーブルを新しく追加しました。
②Relationshipテーブルに一意性制約を追加。



目的
①,②自分のカレンダーを他人に共有するためにフレンド申請機能を実装する上で２者間(自分と他人)での関係性をデータで表現する必要があったためrelationshipテーブルを作成しました。