### PR TITLE
destroyのバグ修正(#142)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,10 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     my_goal_monthly_goal_path(resource)
   end
+
+  def set_q
+    @q = User.ransack(params[:q])
+  end
   
  
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -16,11 +16,12 @@ class RelationshipsController < ApplicationController
   end
 
   def requests_status
-  
-   byebug
+    @user = current_user
+   
     
     #ここに記載する記載する(senderかrecieverかのデータ取得)、そのデータから
   end
+
 
 
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -15,9 +15,10 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+  def destroy
+    super
+    
+  end
 
   # protected
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,9 +30,8 @@ class UsersController < ApplicationController
       format.html { render :index}
     end
 
-    
 end 
-    
+
   private 
 
   def set_q

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,14 +1,14 @@
 header
   nav
     ul
-      li= link_to 'マイページ'  ,     '#'
-      li= link_to 'ログアウト  ',     '#'
-      li= link_to 'フレンド申請状況', requests_status_path(@user)
+      li= link_to 'マイページ',     '#'
+      li= link_to 'ログアウト',     '#'
+      
       -if yield :title == "マイゴール"
-      = search_form_for @q , url: url_for(controller: 'users', action: 'search') do |f|
+      = search_form_for @q , url: url_for(action: 'search') do |f|
         .search
           = f.search_field :name_cont,:placeholder =>"ユーザー名",class: "find-user"
-          =  f.submit '検索'
+          = f.submit '検索'
           
        
-   
+  

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,7 +9,7 @@ html
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
-    = render 'layouts/header'
+    
     p.notice 
       = notice
     p.alert 

--- a/app/views/monthly_goals/my_goal.html.slim
+++ b/app/views/monthly_goals/my_goal.html.slim
@@ -1,4 +1,5 @@
 = provide(:title, "マイゴール") 
+= render 'layouts/header'
 h1 =  "#{@user.name}さんの目標"
 
 section.monthly_goal
@@ -71,4 +72,4 @@ section.penalty
   
 
 = link_to "New Monthly goal", new_monthly_goal_path
-= link_to "ログアウト", destroy_user_session_path, method: :delete
+= link_to "ログアウト",  logout_path, method: :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,14 +18,19 @@ Rails.application.routes.draw do
   end
 
 
-   
+  #  deviseが用意しているデフォルトのコントローラーを使わず自分の環境のusersディレクトリは配下のコントローラーを使えというメソッド
   devise_for :users,  controllers: {
     registrations:  'users/registrations',
     confirmations:  'users/confirmations',
-  }
+    sessions:      'users/sessions',
+     }
+  
+     #↓は↑のusersディレクトリは配下のコントローラーにつなげるようにルーティングを作成するメソッド
   devise_scope :user do
     get '/confirmation_email', to: 'users/confirmations#check_email'
     get '/monthly_goals/new',  to: 'users/monthly_goals#new'
+    delete '/logout',          to: 'users/sessions#destroy'
+    get '/sign_up',            to: 'users/sessions#new'  
   end
 
    post '/monthly_goals/:id/my_goal', to: 'weekly_goals#create'


### PR DESCRIPTION

変更内容
①ログアウトのリンクのpathがdeviseのデフォルトのコントローラーに遷移するように設定されていたので、そうではなくカスタムコントローラーに画面遷移するようにログアウトリンクのurlの変更と、カスタムコントローラーにルーティング先が指定されるようにしました。

