### PR TITLE
my_goal.html.slimのfooterのログアウト後の画面遷移先変更

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,4 +1,4 @@
-class RelationshipsController < ApplicationController
+sclass RelationshipsController < ApplicationController
   before_action :set_q,       only: %i[new create requests_status]
   before_action :friend_user, only: %i[new create ]
   def new

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,6 +18,7 @@ class Users::SessionsController < Devise::SessionsController
   def destroy
     super
     
+    
   end
 
   # protected
@@ -26,4 +27,7 @@ class Users::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+  def after_sign_out_path_for(resource) # flashメッセージの追加もできます
+    sign_up_path
+  end
 end

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -5,10 +5,10 @@ header
       li= link_to 'ログアウト',     '#'
       
       -if yield :title == "マイゴール"
-      = search_form_for @q , url: url_for(action: 'search') do |f|
+      = search_form_for @q , url: url_for(controller: 'users', action: 'search') do |f|
         .search
           = f.search_field :name_cont,:placeholder =>"ユーザー名",class: "find-user"
-          = f.submit '検索'
+          =  f.submit '検索'
           
        
   


### PR DESCRIPTION

変更内容
①my_goal.html.slimのfooterのログアウト後の画面遷移先がlocalhost:3000だったのでsign_upページに遷移できるようにしました。


目的
①ログインとログアウトするのにユーザーさんが迷わないようにするため