### PR TITLE
友達申請通知機能実装

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the notifications controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,5 @@
+class NotificationsController < ApplicationController
+  def index 
+    @notifications = current_user.passive_notifications.where.not(checked:true)
+end
+end 

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -9,12 +9,12 @@ class RelationshipsController < ApplicationController
 
   def create
     #ここbuildメソッドに書きなおす。理由もし同時に
-  
-   friendship = Relationship.new(relationship_params)
-   if friendship.save
-    redirect_to  my_goal_monthly_goal_path(current_user)
+   relationship = Relationship.new(relationship_params)
+   if relationship.save
+      redirect_to  my_goal_monthly_goal_path(current_user)
+      current_user.create_notification_follow!(current_user,params[:relationship][:reciever_id])
+
    else
-    
     
    end
   end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,2 @@
+module NotificationsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,18 @@ def collect_user_events(user_weekly_goals)
   events
 end 
 
+def  create_notification_follow!(current_user,friend_id)
+  notification = Notification.where(["visitor_id = ? and visited_id = ? and action = ? ",current_user.id, friend_id, 'follow'])
+  if notification.blank?
+    notification = current_user.active_notifications.new(
+      visited_id: friend_id,
+      action: 'follow'
+    )
+    notification.save if notification.valid?
+    
+  end
+end
+
 
 
 

--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -1,0 +1,8 @@
+- visitor = notification.visitor
+- visited = notification.visited
+
+
+- case notification.action
+- when 'follow'
+  = "#{visitor.name}さんがあなたに友達申請を送りました"
+  

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -1,0 +1,6 @@
+- notifications = @notifications
+- if notifications.exists?
+  = render notifications
+- else
+  p
+    | 通知はありません


### PR DESCRIPTION

変更内容
①友達申請するとnotificationテーブルに誰が誰に友達申請したかの情報のレコードが登録されるように変更しました。


目的
①友達申請後に友達申請相手に通知を送るためにnotificationテーブルにレコードの登録が必要だったので