### PR TITLE
request_status.html.slimでフレンドリクエストもらってる時ともらっていない時で表示内容を変更する

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -22,8 +22,8 @@ class RelationshipsController < ApplicationController
   end
 
   def requests_status
-   @friend_request_reciever = current_user.reciever_relationships
-
+    @friend_request_reciever = current_user.reciever_relationships
+    @friend_request_sender =  Relationship.get_sender(@friend_request_reciever)
   end
 
 

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -5,8 +5,11 @@ class Relationship < ApplicationRecord
   validates :reciever_id, presence: true, uniqueness: true
 
 
-
-
+  def self.get_sender(friend_request_reciever)
+    if !friend_request_reciever.nil?
+        friend_request_reciever.sender
+    end 
+  end 
 
 end
 

--- a/app/views/relationships/requests_status.html.slim
+++ b/app/views/relationships/requests_status.html.slim
@@ -1,4 +1,10 @@
-- if  @friend_request_reciever.nil?
-
+- if @friend_request_reciever.nil?
+  h1 なにもありません
+  = button_to "戻る",my_goal_monthly_goal_path(current_user),{method: :get}
 
 - else
+  h2 #{@friend_request_sender.name}さんから友達申請依頼が届いてます
+  = button_to "許可",my_goal_monthly_goal_path(current_user),{method: :get}
+  = button_to "拒否",my_goal_monthly_goal_path(current_user),{method: :get}
+
+


### PR DESCRIPTION

変更内容
①フォローをもらったユーザーはフォローしてきたユーザーをフレンドとして許可するかしないかを選べるようにしました。
フォローをまだもらってないユーザーはなにもありませんと表示するように変更しました。

目的
①フレンド許可したユーザーだけの目標をお互い共有できるようにしたいため